### PR TITLE
Allow field strategy to use the constant values instead of their name

### DIFF
--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/AbstractField.php
@@ -30,7 +30,7 @@ abstract class AbstractField implements Annotation
         ?string $type = null,
         bool $nullable = false,
         array $options = [],
-        ?string $strategy = null,
+        string|int|null $strategy = null,
         bool $notSaved = false,
     ) {
         $this->name     = $name;

--- a/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/Annotations/Id.php
@@ -24,7 +24,7 @@ final class Id extends AbstractField
         ?string $type = null,
         bool $nullable = false,
         array $options = [],
-        ?string $strategy = 'auto',
+        string|int|null $strategy = 'auto',
         bool $notSaved = false,
     ) {
         parent::__construct($name, $type, $nullable, $options, $strategy, $notSaved);

--- a/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php
@@ -2358,7 +2358,7 @@ use function trigger_deprecation;
             $mapping['name']  = '_id';
             $this->identifier = $mapping['fieldName'];
             if (isset($mapping['strategy'])) {
-                $this->generatorType = constant(self::class . '::GENERATOR_TYPE_' . strtoupper($mapping['strategy']));
+                $this->generatorType = is_string($mapping['strategy']) ? constant(self::class . '::GENERATOR_TYPE_' . strtoupper($mapping['strategy'])) : $mapping['strategy'];
             }
 
             $this->generatorOptions = $mapping['options'] ?? [];


### PR DESCRIPTION
- [ ] Add tests
- [ ] fix other strategies
- [ ] validate value, currently the const name limit which name can be used

Should use an enum.